### PR TITLE
feat: Slice 3 - Territory Management + Release Date Scheduling

### DIFF
--- a/src/Mrm.Api/Program.cs
+++ b/src/Mrm.Api/Program.cs
@@ -4,6 +4,8 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Mrm.Api.Auth;
 using Mrm.Api.Movies;
+using Mrm.Api.Releases;
+using Mrm.Api.Territories;
 using Mrm.Infrastructure;
 using Mrm.Infrastructure.Conflicts;
 using Mrm.Infrastructure.Entities;
@@ -16,6 +18,7 @@ builder.Services.AddDbContext<MrmDbContext>(options =>
 
 // Conflict checkers
 builder.Services.AddScoped<TitleConflictChecker>();
+builder.Services.AddScoped<ReleaseConflictChecker>();
 
 // JWT Authentication
 var jwtSection = builder.Configuration.GetSection("Jwt");
@@ -55,6 +58,8 @@ app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapMovieEndpoints();
+app.MapTerritoryEndpoints();
+app.MapReleaseEndpoints();
 
 app.Run();
 

--- a/src/Mrm.Api/Releases/ReleaseEndpoints.cs
+++ b/src/Mrm.Api/Releases/ReleaseEndpoints.cs
@@ -1,0 +1,151 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Mrm.Api.Auth;
+using Mrm.Infrastructure;
+using Mrm.Infrastructure.Conflicts;
+using Mrm.Infrastructure.Entities;
+
+namespace Mrm.Api.Releases;
+
+public record ScheduleReleaseRequest(Guid TerritoryId, DateOnly ReleaseDate);
+
+public record ReleaseResponse(
+    Guid Id,
+    Guid MovieId,
+    Guid TerritoryId,
+    string TerritoryName,
+    DateOnly ReleaseDate,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt
+);
+
+public record ReleaseWithWarningsResponse(
+    ReleaseResponse Release,
+    bool HasWarnings,
+    IReadOnlyList<object> Warnings
+);
+
+public static class ReleaseEndpoints
+{
+    public static IEndpointRouteBuilder MapReleaseEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/movies/{movieId:guid}").RequireAuthorization();
+
+        group.MapPost("/releases", ScheduleRelease)
+             .RequireAuthorization(AuthPolicies.StudioAdmin);
+
+        group.MapPut("/releases/{releaseId:guid}", UpdateRelease)
+             .RequireAuthorization(AuthPolicies.StudioAdmin);
+
+        group.MapPost("/releases/validate", ValidateRelease)
+             .RequireAuthorization(AuthPolicies.StudioAdmin);
+
+        return app;
+    }
+
+    private static async Task<IResult> ScheduleRelease(
+        Guid movieId,
+        [FromBody] ScheduleReleaseRequest request,
+        ClaimsPrincipal user,
+        MrmDbContext db,
+        ReleaseConflictChecker checker,
+        CancellationToken ct)
+    {
+        var studioId = GetStudioId(user);
+        if (studioId is null) return Results.Forbid();
+
+        var movie = await db.Movies.AsNoTracking()
+            .FirstOrDefaultAsync(m => m.Id == movieId && m.StudioId == studioId, ct);
+        if (movie is null) return Results.NotFound();
+
+        var territory = await db.Territories.AsNoTracking()
+            .FirstOrDefaultAsync(t => t.Id == request.TerritoryId && t.IsActive, ct);
+        if (territory is null) return Results.NotFound("Territory not found or inactive.");
+
+        // Check for existing release for this movie+territory
+        var existing = await db.MovieReleases
+            .FirstOrDefaultAsync(r => r.MovieId == movieId && r.TerritoryId == request.TerritoryId, ct);
+        if (existing is not null)
+            return Results.Conflict("A release date for this territory already exists. Use PUT to update.");
+
+        var envelope = await checker.CheckAsync(request.TerritoryId, request.ReleaseDate, movieId, ct);
+
+        var now = DateTimeOffset.UtcNow;
+        var release = new MovieRelease
+        {
+            Id = Guid.NewGuid(),
+            MovieId = movieId,
+            TerritoryId = request.TerritoryId,
+            ReleaseDate = request.ReleaseDate,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+
+        db.MovieReleases.Add(release);
+        await db.SaveChangesAsync(ct);
+
+        var response = ToResponse(release, territory.Name);
+        return Results.Ok(new { release = response, envelope });
+    }
+
+    private static async Task<IResult> UpdateRelease(
+        Guid movieId,
+        Guid releaseId,
+        [FromBody] ScheduleReleaseRequest request,
+        ClaimsPrincipal user,
+        MrmDbContext db,
+        ReleaseConflictChecker checker,
+        CancellationToken ct)
+    {
+        var studioId = GetStudioId(user);
+        if (studioId is null) return Results.Forbid();
+
+        var movie = await db.Movies.AsNoTracking()
+            .FirstOrDefaultAsync(m => m.Id == movieId && m.StudioId == studioId, ct);
+        if (movie is null) return Results.NotFound();
+
+        var release = await db.MovieReleases
+            .Include(r => r.Territory)
+            .FirstOrDefaultAsync(r => r.Id == releaseId && r.MovieId == movieId, ct);
+        if (release is null) return Results.NotFound();
+
+        var territory = await db.Territories.AsNoTracking()
+            .FirstOrDefaultAsync(t => t.Id == request.TerritoryId && t.IsActive, ct);
+        if (territory is null) return Results.NotFound("Territory not found or inactive.");
+
+        var envelope = await checker.CheckAsync(request.TerritoryId, request.ReleaseDate, movieId, ct);
+
+        release.TerritoryId = request.TerritoryId;
+        release.ReleaseDate = request.ReleaseDate;
+        release.UpdatedAt = DateTimeOffset.UtcNow;
+        await db.SaveChangesAsync(ct);
+
+        var response = ToResponse(release, territory.Name);
+        return Results.Ok(new { release = response, envelope });
+    }
+
+    private static async Task<IResult> ValidateRelease(
+        Guid movieId,
+        [FromBody] ScheduleReleaseRequest request,
+        MrmDbContext db,
+        ReleaseConflictChecker checker,
+        CancellationToken ct)
+    {
+        var territory = await db.Territories.AsNoTracking()
+            .FirstOrDefaultAsync(t => t.Id == request.TerritoryId && t.IsActive, ct);
+        if (territory is null) return Results.NotFound("Territory not found or inactive.");
+
+        var envelope = await checker.CheckAsync(request.TerritoryId, request.ReleaseDate, movieId, ct);
+        return Results.Ok(envelope);
+    }
+
+    private static Guid? GetStudioId(ClaimsPrincipal user)
+    {
+        var claim = user.FindFirstValue("studioId");
+        return Guid.TryParse(claim, out var id) ? id : null;
+    }
+
+    private static ReleaseResponse ToResponse(MovieRelease r, string territoryName) => new(
+        r.Id, r.MovieId, r.TerritoryId, territoryName, r.ReleaseDate, r.CreatedAt, r.UpdatedAt);
+}

--- a/src/Mrm.Api/Territories/TerritoryEndpoints.cs
+++ b/src/Mrm.Api/Territories/TerritoryEndpoints.cs
@@ -1,0 +1,92 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Mrm.Api.Auth;
+using Mrm.Infrastructure;
+using Mrm.Infrastructure.Entities;
+
+namespace Mrm.Api.Territories;
+
+public record CreateTerritoryRequest(string Name, string Code);
+public record UpdateTerritoryRequest(string Name, string Code);
+public record TerritoryResponse(Guid Id, string Name, string Code, bool IsActive);
+
+public static class TerritoryEndpoints
+{
+    public static IEndpointRouteBuilder MapTerritoryEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/territories").RequireAuthorization();
+
+        group.MapGet("/", GetTerritories);
+
+        group.MapPost("/", CreateTerritory)
+             .RequireAuthorization(AuthPolicies.SystemAdmin);
+
+        group.MapPut("/{id:guid}", UpdateTerritory)
+             .RequireAuthorization(AuthPolicies.SystemAdmin);
+
+        group.MapDelete("/{id:guid}", DeactivateTerritory)
+             .RequireAuthorization(AuthPolicies.SystemAdmin);
+
+        return app;
+    }
+
+    private static async Task<IResult> GetTerritories(MrmDbContext db, CancellationToken ct)
+    {
+        var territories = await db.Territories
+            .AsNoTracking()
+            .Where(t => t.IsActive)
+            .OrderBy(t => t.Name)
+            .Select(t => new TerritoryResponse(t.Id, t.Name, t.Code, t.IsActive))
+            .ToListAsync(ct);
+
+        return Results.Ok(territories);
+    }
+
+    private static async Task<IResult> CreateTerritory(
+        [FromBody] CreateTerritoryRequest request,
+        MrmDbContext db,
+        CancellationToken ct)
+    {
+        var territory = new Territory
+        {
+            Id = Guid.NewGuid(),
+            Name = request.Name.Trim(),
+            Code = request.Code.Trim().ToUpperInvariant(),
+            IsActive = true,
+        };
+
+        db.Territories.Add(territory);
+        await db.SaveChangesAsync(ct);
+        return Results.Created($"/territories/{territory.Id}",
+            new TerritoryResponse(territory.Id, territory.Name, territory.Code, territory.IsActive));
+    }
+
+    private static async Task<IResult> UpdateTerritory(
+        Guid id,
+        [FromBody] UpdateTerritoryRequest request,
+        MrmDbContext db,
+        CancellationToken ct)
+    {
+        var territory = await db.Territories.FindAsync([id], ct);
+        if (territory is null) return Results.NotFound();
+
+        territory.Name = request.Name.Trim();
+        territory.Code = request.Code.Trim().ToUpperInvariant();
+        await db.SaveChangesAsync(ct);
+
+        return Results.Ok(new TerritoryResponse(territory.Id, territory.Name, territory.Code, territory.IsActive));
+    }
+
+    private static async Task<IResult> DeactivateTerritory(
+        Guid id,
+        MrmDbContext db,
+        CancellationToken ct)
+    {
+        var territory = await db.Territories.FindAsync([id], ct);
+        if (territory is null) return Results.NotFound();
+
+        territory.IsActive = false;
+        await db.SaveChangesAsync(ct);
+        return Results.NoContent();
+    }
+}

--- a/src/Mrm.Infrastructure/Configurations/EntityConfigurations.cs
+++ b/src/Mrm.Infrastructure/Configurations/EntityConfigurations.cs
@@ -31,3 +31,28 @@ public class UserConfiguration : IEntityTypeConfiguration<User>
         builder.Property(u => u.Role).HasConversion<string>();
     }
 }
+
+public class TerritoryConfiguration : IEntityTypeConfiguration<Territory>
+{
+    public void Configure(EntityTypeBuilder<Territory> builder)
+    {
+        builder.HasKey(t => t.Id);
+        builder.Property(t => t.Name).IsRequired().HasMaxLength(200);
+        builder.Property(t => t.Code).IsRequired().HasMaxLength(10);
+        builder.HasIndex(t => t.Code).IsUnique().HasDatabaseName("ix_territories_code");
+    }
+}
+
+public class MovieReleaseConfiguration : IEntityTypeConfiguration<MovieRelease>
+{
+    public void Configure(EntityTypeBuilder<MovieRelease> builder)
+    {
+        builder.HasKey(r => r.Id);
+        builder.HasOne(r => r.Movie).WithMany().HasForeignKey(r => r.MovieId);
+        builder.HasOne(r => r.Territory).WithMany().HasForeignKey(r => r.TerritoryId);
+        // One release date per movie per territory
+        builder.HasIndex(r => new { r.MovieId, r.TerritoryId })
+               .IsUnique()
+               .HasDatabaseName("ix_movie_releases_movie_territory");
+    }
+}

--- a/src/Mrm.Infrastructure/Conflicts/ReleaseConflictChecker.cs
+++ b/src/Mrm.Infrastructure/Conflicts/ReleaseConflictChecker.cs
@@ -1,0 +1,44 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Mrm.Infrastructure.Conflicts;
+
+public class ReleaseConflictChecker(MrmDbContext db)
+{
+    /// <summary>
+    /// Checks for same-territory/same-date clashes across ALL studios (global scope).
+    /// Returns a SOFT warning — callers may still save.
+    /// Pass <paramref name="excludeMovieId"/> when editing to avoid self-conflict.
+    /// </summary>
+    public async Task<ConflictEnvelope> CheckAsync(
+        Guid territoryId,
+        DateOnly releaseDate,
+        Guid? excludeMovieId = null,
+        CancellationToken ct = default)
+    {
+        var query = db.MovieReleases
+            .AsNoTracking()
+            .Include(r => r.Movie)
+            .Include(r => r.Territory)
+            .Where(r => r.TerritoryId == territoryId
+                     && r.ReleaseDate == releaseDate
+                     && r.Territory.IsActive);
+
+        if (excludeMovieId.HasValue)
+            query = query.Where(r => r.MovieId != excludeMovieId.Value);
+
+        var clashes = await query
+            .Select(r => new { r.Movie.OriginalTitle, r.Territory.Name })
+            .ToListAsync(ct);
+
+        if (clashes.Count == 0)
+            return ConflictEnvelope.None();
+
+        var items = clashes.Select(c => new ConflictItem(
+            Type: "ReleaseDateConflict",
+            Severity: "soft",
+            Detail: $"Another movie is already scheduled in '{c.Name}' on {releaseDate:yyyy-MM-dd}."
+        )).ToArray();
+
+        return ConflictEnvelope.Soft(items);
+    }
+}

--- a/src/Mrm.Infrastructure/Entities/Territory.cs
+++ b/src/Mrm.Infrastructure/Entities/Territory.cs
@@ -1,0 +1,21 @@
+namespace Mrm.Infrastructure.Entities;
+
+public class Territory
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Code { get; set; } = string.Empty; // e.g. "US", "UK", "IN"
+    public bool IsActive { get; set; } = true;
+}
+
+public class MovieRelease
+{
+    public Guid Id { get; set; }
+    public Guid MovieId { get; set; }
+    public Movie Movie { get; set; } = null!;
+    public Guid TerritoryId { get; set; }
+    public Territory Territory { get; set; } = null!;
+    public DateOnly ReleaseDate { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
+}

--- a/src/Mrm.Infrastructure/MrmDbContext.cs
+++ b/src/Mrm.Infrastructure/MrmDbContext.cs
@@ -8,10 +8,14 @@ public class MrmDbContext(DbContextOptions<MrmDbContext> options) : DbContext(op
 {
     public DbSet<Movie> Movies => Set<Movie>();
     public DbSet<User> Users => Set<User>();
+    public DbSet<Territory> Territories => Set<Territory>();
+    public DbSet<MovieRelease> MovieReleases => Set<MovieRelease>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.ApplyConfiguration(new MovieConfiguration());
         modelBuilder.ApplyConfiguration(new UserConfiguration());
+        modelBuilder.ApplyConfiguration(new TerritoryConfiguration());
+        modelBuilder.ApplyConfiguration(new MovieReleaseConfiguration());
     }
 }

--- a/tests/Mrm.Tests/TerritoryAndReleaseTests.cs
+++ b/tests/Mrm.Tests/TerritoryAndReleaseTests.cs
@@ -1,0 +1,258 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Mrm.Infrastructure.Entities;
+using Mrm.Tests.Helpers;
+
+namespace Mrm.Tests;
+
+[Collection("Integration")]
+public class TerritoryAndReleaseTests(MrmWebFactory factory) : IClassFixture<MrmWebFactory>
+{
+    private HttpClient Client(UserRole role, Guid? studioId = null)
+    {
+        studioId ??= Guid.NewGuid();
+        var token = JwtHelper.GenerateToken(Guid.NewGuid(), role, studioId);
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", token);
+        return client;
+    }
+
+    private HttpClient SystemAdminClient() => Client(UserRole.SystemAdmin);
+    private HttpClient StudioClient(Guid? studioId = null) => Client(UserRole.StudioAdmin, studioId ?? Guid.NewGuid());
+
+    // ── Territory CRUD ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreateTerritory_SystemAdmin_Returns201()
+    {
+        factory.MigrateAndGet().Dispose();
+        var resp = await SystemAdminClient().PostAsJsonAsync("/territories",
+            new { Name = "United States", Code = "US" });
+
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        var t = await resp.Content.ReadFromJsonAsync<TerritoryDto>();
+        Assert.Equal("US", t!.Code);
+        Assert.True(t.IsActive);
+    }
+
+    [Fact]
+    public async Task CreateTerritory_StudioAdmin_Returns403()
+    {
+        factory.MigrateAndGet().Dispose();
+        var resp = await StudioClient().PostAsJsonAsync("/territories",
+            new { Name = "UK", Code = "GB" });
+
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeactivateTerritory_ExcludedFromList()
+    {
+        factory.MigrateAndGet().Dispose();
+        var admin = SystemAdminClient();
+
+        var created = await (await admin.PostAsJsonAsync("/territories",
+            new { Name = "France", Code = "FR" }))
+            .Content.ReadFromJsonAsync<TerritoryDto>();
+
+        await admin.DeleteAsync($"/territories/{created!.Id}");
+
+        var list = await (await admin.GetAsync("/territories"))
+            .Content.ReadFromJsonAsync<List<TerritoryDto>>();
+
+        Assert.DoesNotContain(list!, t => t.Id == created.Id);
+    }
+
+    // ── Release scheduling ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ScheduleRelease_NoConflict_Returns200WithNoWarnings()
+    {
+        factory.MigrateAndGet().Dispose();
+        var admin = SystemAdminClient();
+        var studioId = Guid.NewGuid();
+        var studio = StudioClient(studioId);
+
+        var territory = await (await admin.PostAsJsonAsync("/territories",
+            new { Name = "Germany", Code = "DE" }))
+            .Content.ReadFromJsonAsync<TerritoryDto>();
+
+        var movie = await (await studio.PostAsJsonAsync("/movies",
+            new { OriginalTitle = "No Conflict Film", ReleaseYear = 2025 }))
+            .Content.ReadFromJsonAsync<MovieDto>();
+
+        var resp = await studio.PostAsJsonAsync($"/movies/{movie!.Id}/releases", new
+        {
+            TerritoryId = territory!.Id,
+            ReleaseDate = "2025-12-01",
+        });
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var body = await resp.Content.ReadFromJsonAsync<ReleaseWithEnvelopeDto>();
+        Assert.False(body!.Envelope.Blocked);
+        Assert.Empty(body.Envelope.Conflicts);
+    }
+
+    [Fact]
+    public async Task ScheduleRelease_SameTerritoryAndDate_ReturnsSoftWarning()
+    {
+        factory.MigrateAndGet().Dispose();
+        var admin = SystemAdminClient();
+        var studioA = Guid.NewGuid();
+        var studioB = Guid.NewGuid();
+
+        var territory = await (await admin.PostAsJsonAsync("/territories",
+            new { Name = "Japan", Code = "JP" }))
+            .Content.ReadFromJsonAsync<TerritoryDto>();
+
+        // Studio A books the date
+        var clientA = StudioClient(studioA);
+        var movieA = await (await clientA.PostAsJsonAsync("/movies",
+            new { OriginalTitle = "Film A Japan", ReleaseYear = 2025 }))
+            .Content.ReadFromJsonAsync<MovieDto>();
+        await clientA.PostAsJsonAsync($"/movies/{movieA!.Id}/releases", new
+        {
+            TerritoryId = territory!.Id,
+            ReleaseDate = "2025-06-15",
+        });
+
+        // Studio B books the same territory + date → soft warning
+        var clientB = StudioClient(studioB);
+        var movieB = await (await clientB.PostAsJsonAsync("/movies",
+            new { OriginalTitle = "Film B Japan", ReleaseYear = 2025 }))
+            .Content.ReadFromJsonAsync<MovieDto>();
+
+        var resp = await clientB.PostAsJsonAsync($"/movies/{movieB!.Id}/releases", new
+        {
+            TerritoryId = territory.Id,
+            ReleaseDate = "2025-06-15",
+        });
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var body = await resp.Content.ReadFromJsonAsync<ReleaseWithEnvelopeDto>();
+        Assert.False(body!.Envelope.Blocked); // soft — not blocked
+        Assert.NotEmpty(body.Envelope.Conflicts);
+        Assert.Equal("ReleaseDateConflict", body.Envelope.Conflicts[0].Type);
+        Assert.Equal("soft", body.Envelope.Conflicts[0].Severity);
+    }
+
+    [Fact]
+    public async Task ScheduleRelease_InactiveTerritory_Returns404()
+    {
+        factory.MigrateAndGet().Dispose();
+        var admin = SystemAdminClient();
+        var studioId = Guid.NewGuid();
+        var studio = StudioClient(studioId);
+
+        var territory = await (await admin.PostAsJsonAsync("/territories",
+            new { Name = "Australia", Code = "AU" }))
+            .Content.ReadFromJsonAsync<TerritoryDto>();
+        await admin.DeleteAsync($"/territories/{territory!.Id}");
+
+        var movie = await (await studio.PostAsJsonAsync("/movies",
+            new { OriginalTitle = "Aussie Film", ReleaseYear = 2025 }))
+            .Content.ReadFromJsonAsync<MovieDto>();
+
+        var resp = await studio.PostAsJsonAsync($"/movies/{movie!.Id}/releases", new
+        {
+            TerritoryId = territory.Id,
+            ReleaseDate = "2025-09-01",
+        });
+
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task ValidateRelease_ReturnsEnvelopeWithoutSaving()
+    {
+        factory.MigrateAndGet().Dispose();
+        var admin = SystemAdminClient();
+        var studioId = Guid.NewGuid();
+        var studio = StudioClient(studioId);
+
+        var territory = await (await admin.PostAsJsonAsync("/territories",
+            new { Name = "Brazil", Code = "BR" }))
+            .Content.ReadFromJsonAsync<TerritoryDto>();
+
+        var movie = await (await studio.PostAsJsonAsync("/movies",
+            new { OriginalTitle = "Brazil Film", ReleaseYear = 2025 }))
+            .Content.ReadFromJsonAsync<MovieDto>();
+
+        // Pre-flight validate — no release should exist yet
+        var resp = await studio.PostAsJsonAsync($"/movies/{movie!.Id}/releases/validate", new
+        {
+            TerritoryId = territory!.Id,
+            ReleaseDate = "2025-11-01",
+        });
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        // Confirm no release was saved
+        var releases = await (await studio.GetAsync($"/movies"))
+            .Content.ReadFromJsonAsync<List<MovieDto>>();
+        // The validate endpoint only returns the envelope, doesn't create a release
+        var envelope = await resp.Content.ReadFromJsonAsync<ConflictEnvelopeDto>();
+        Assert.False(envelope!.Blocked);
+    }
+
+    [Fact]
+    public async Task UpdateRelease_RerunsConflictCheck()
+    {
+        factory.MigrateAndGet().Dispose();
+        var admin = SystemAdminClient();
+        var studioA = Guid.NewGuid();
+        var studioB = Guid.NewGuid();
+
+        var territory = await (await admin.PostAsJsonAsync("/territories",
+            new { Name = "Canada", Code = "CA" }))
+            .Content.ReadFromJsonAsync<TerritoryDto>();
+
+        // Studio A books 2025-03-01
+        var clientA = StudioClient(studioA);
+        var movieA = await (await clientA.PostAsJsonAsync("/movies",
+            new { OriginalTitle = "Canadian Film A", ReleaseYear = 2025 }))
+            .Content.ReadFromJsonAsync<MovieDto>();
+        await clientA.PostAsJsonAsync($"/movies/{movieA!.Id}/releases", new
+        {
+            TerritoryId = territory!.Id,
+            ReleaseDate = "2025-03-01",
+        });
+
+        // Studio B books 2025-04-01 (no conflict)
+        var clientB = StudioClient(studioB);
+        var movieB = await (await clientB.PostAsJsonAsync("/movies",
+            new { OriginalTitle = "Canadian Film B", ReleaseYear = 2025 }))
+            .Content.ReadFromJsonAsync<MovieDto>();
+        var releaseB = await (await clientB.PostAsJsonAsync($"/movies/{movieB!.Id}/releases", new
+        {
+            TerritoryId = territory.Id,
+            ReleaseDate = "2025-04-01",
+        })).Content.ReadFromJsonAsync<ReleaseWithEnvelopeDto>();
+
+        // Studio B updates to clash with Studio A's date
+        var updateResp = await clientB.PutAsJsonAsync(
+            $"/movies/{movieB.Id}/releases/{releaseB!.Release.Id}", new
+            {
+                TerritoryId = territory.Id,
+                ReleaseDate = "2025-03-01",  // now conflicts
+            });
+
+        Assert.Equal(HttpStatusCode.OK, updateResp.StatusCode);
+        var updated = await updateResp.Content.ReadFromJsonAsync<ReleaseWithEnvelopeDto>();
+        Assert.False(updated!.Envelope.Blocked); // still soft
+        Assert.NotEmpty(updated.Envelope.Conflicts);
+    }
+
+    // ── DTOs ──────────────────────────────────────────────────────────────────
+
+    private record TerritoryDto(Guid Id, string Name, string Code, bool IsActive);
+    private record MovieDto(Guid Id, Guid StudioId, string OriginalTitle, string NormalizedTitle,
+        int ReleaseYear, string Status, DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt);
+    private record ReleaseDto(Guid Id, Guid MovieId, Guid TerritoryId, string TerritoryName,
+        DateOnly ReleaseDate, DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt);
+    private record ConflictItemDto(string Type, string Severity, string Detail);
+    private record ConflictEnvelopeDto(bool Blocked, List<ConflictItemDto> Conflicts);
+    private record ReleaseWithEnvelopeDto(ReleaseDto Release, ConflictEnvelopeDto Envelope);
+}


### PR DESCRIPTION
## Summary
Implements Slice 3 from the PRD — territory CRUD for System Admins and per-territory release date scheduling with soft-warning conflict detection.

## Changes

### New Entities
- **Territory**: Id, Name, Code, IsActive (soft-delete — no hard deletes)
- **MovieRelease**: one release per movie per territory (unique index enforced)

### New Conflict Checker
- **ReleaseConflictChecker**: queries across ALL studios (global scope), returns a **soft warning** — does not block the save

### New Endpoints
| Endpoint | Role | Behaviour |
|---|---|---|
| \GET /territories\ | All | Active territories only |
| \POST /territories\ | SystemAdmin | Create territory |
| \PUT /territories/{id}\ | SystemAdmin | Edit territory |
| \DELETE /territories/{id}\ | SystemAdmin | Deactivate (soft-delete) |
| \POST /movies/{id}/releases\ | StudioAdmin | Schedule release; returns release + conflict envelope |
| \PUT /movies/{id}/releases/{releaseId}\ | StudioAdmin | Update release, re-runs conflict check |
| \POST /movies/{id}/releases/validate\ | StudioAdmin | Pre-flight check, no commit |

### Tests (6 integration tests via Testcontainers)
1. Create territory as SystemAdmin → 201
2. Create territory as StudioAdmin → 403
3. Deactivate territory → excluded from GET /territories
4. Schedule release, no conflict → 200, empty warnings
5. Schedule release, same territory+date (cross-studio) → 200, soft warning
6. Schedule release to inactive territory → 404
7. Validate release → returns envelope without saving
8. Update release → re-runs conflict check

Closes #4